### PR TITLE
Fix deprecation warnings

### DIFF
--- a/UDEFX2/Misc.c
+++ b/UDEFX2/Misc.c
@@ -147,7 +147,7 @@ WRQueuePushWrite(
         status = STATUS_SUCCESS; // til proven otherwise
 
         // allocate
-        pNewEntry = ExAllocatePool(PagedPool, sizeof(BUFFER_CONTENT) + wlen);
+        pNewEntry = ExAllocatePool2(POOL_FLAG_PAGED, sizeof(BUFFER_CONTENT) + wlen, UDEFX_POOL_TAG);
         if (pNewEntry == NULL) {
             TraceEvents(TRACE_LEVEL_ERROR,
                 TRACE_QUEUE,

--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -277,7 +277,7 @@ Usb_ReadDescriptorsAndPlugIn(
     // Compute configuration descriptor dynamically.
     //
     pComputedConfigDescSet = (PUSB_CONFIGURATION_DESCRIPTOR)
-        ExAllocatePoolWithTag(NonPagedPoolNx, sizeof(g_UsbConfigDescriptorSet), UDECXMBIM_POOL_TAG);
+        ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(g_UsbConfigDescriptorSet), UDECXMBIM_POOL_TAG);
 
     if (pComputedConfigDescSet == NULL) {
 


### PR DESCRIPTION
Based on instructions on [Updating deprecated ExAllocatePool calls to ExAllocatePool2 and ExAllocatePool3](https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/updating-deprecated-exallocatepool-calls)

Fixes the following compiler warnings:
```
UDEFX2\Misc.c(150,21): warning C4996: 'ExAllocatePool': ExAllocatePool is deprecated, use ExAllocatePool2. 
UDEFX2\usbdevice.c(280,9): warning C4996: 'ExAllocatePoolWithTag': ExAllocatePoolWithTag is deprecated, use ExAllocatePool2.
```