### PR TITLE
Copy devcon.exe as post-build event

### DIFF
--- a/UDEFX2/UDEFX2.vcxproj
+++ b/UDEFX2/UDEFX2.vcxproj
@@ -177,6 +177,9 @@
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x86\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -191,6 +194,9 @@
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x86\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -205,6 +211,9 @@
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -219,6 +228,9 @@
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
@@ -230,6 +242,9 @@
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\arm\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
@@ -241,6 +256,9 @@
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\arm\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
@@ -252,6 +270,9 @@
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\arm64\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
@@ -263,6 +284,9 @@
     <Link>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\arm64\devcon.exe" $(PackageDir)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <FilesToPackage Include="$(TargetPath)" />

--- a/UDEFX_host/driver/hostude.vcxproj
+++ b/UDEFX_host/driver/hostude.vcxproj
@@ -62,9 +62,6 @@
     <ConfigurationType>Driver</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <PropertyGroup>
-    <OutDir>$(IntDir)</OutDir>
-  </PropertyGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
@@ -198,7 +195,7 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(ProjectDir)$(IntDir) /os:10_x64</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x64</Command>
       <Message>catalog file for x64 release</Message>
     </PostBuildEvent>
     <DriverSign>
@@ -211,7 +208,7 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(ProjectDir)$(IntDir) /os:10_x64</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x64</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>catalog file for x64 debug</Message>
@@ -226,7 +223,7 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(ProjectDir)$(IntDir) /os:10_x86</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x86</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>inf2cat for win32 release</Message>
@@ -241,7 +238,7 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(ProjectDir)$(IntDir) /os:10_x86</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x86</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>inf2cat for win32 debug</Message>

--- a/UDEFX_host/driver/hostude.vcxproj
+++ b/UDEFX_host/driver/hostude.vcxproj
@@ -195,7 +195,8 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(OutDir) /os:10_x64</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x64
+copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\devcon.exe" $(OutDir)</Command>
       <Message>catalog file for x64 release</Message>
     </PostBuildEvent>
     <DriverSign>
@@ -208,7 +209,8 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(OutDir) /os:10_x64</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x64
+copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\devcon.exe" $(OutDir)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>catalog file for x64 debug</Message>
@@ -223,7 +225,8 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(OutDir) /os:10_x86</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x86
+copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x86\devcon.exe" $(OutDir)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>inf2cat for win32 release</Message>
@@ -238,7 +241,8 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>inf2cat /driver:$(OutDir) /os:10_x86</Command>
+      <Command>inf2cat /driver:$(OutDir) /os:10_x86
+copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x86\devcon.exe" $(OutDir)</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>inf2cat for win32 debug</Message>

--- a/UDEFX_host/exe/hostudetest.vcxproj
+++ b/UDEFX_host/exe/hostudetest.vcxproj
@@ -59,9 +59,6 @@
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <PropertyGroup>
-    <OutDir>$(IntDir)</OutDir>
-  </PropertyGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>


### PR DESCRIPTION
Copy `devcon.exe` together with the driver INF/SYS files as a post-build event. Done to ease driver installation & testing on computers without the WDK installed.