### PR TITLE
Add ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+/UDEFX_host/.vs
+/UDEFX_host/driver/x64
+/UDEFX_host/exe/x64
+/UDEFX_host/x64
+
+/UDEFX2/.vs
+/UDEFX2/ARM64
+/UDEFX2/x64


### PR DESCRIPTION
Ignore Visual Studio (`.vs`) folders and `ARM64`/`x64` binary folders.