### PR TITLE
Enable Inf2CatUseLocalTime to fix build failure right after midnight

### DIFF
--- a/UDEFX2/UDEFX2.vcxproj
+++ b/UDEFX2/UDEFX2.vcxproj
@@ -94,15 +94,19 @@
   <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/UDEFX_host/driver/hostude.vcxproj
+++ b/UDEFX_host/driver/hostude.vcxproj
@@ -105,9 +105,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ALLOW_DATE_TIME>1</ALLOW_DATE_TIME>
     <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ALLOW_DATE_TIME>1</ALLOW_DATE_TIME>
+    <Inf2CatUseLocalTime>true</Inf2CatUseLocalTime>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>


### PR DESCRIPTION
Done to fix the following error when building between midnight and 2AM on a computer configured in the GMT+2 time-zone:
```
>22.9.7: DriverVer set to a date in the future (postdated DriverVer not allowed)
```

Problem description: https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/inf2cat#troubleshooting