### PR TITLE
Delete driver_both.txt to reduce the maintenance burden

### DIFF
--- a/UDEFX2/share.bat
+++ b/UDEFX2/share.bat
@@ -1,7 +1,0 @@
-@setlocal
-mkdir %userprofile%\vmshare\usbt >nul 2>&1
-copy /y x64\Debug\UDEFX2.sys %userprofile%\vmshare\usbt
-copy /y x64\Debug\UDEFX2.inf %userprofile%\vmshare\usbt
-copy /y x64\Debug\UDEFX2\udefx2.cat %userprofile%\vmshare\usbt
-copy /y trace\*.bat %userprofile%\vmshare\usbt
-

--- a/UDEFX_host/driver_both.txt
+++ b/UDEFX_host/driver_both.txt
@@ -1,5 +1,0 @@
-@rem first this one, before plugging in
-devcon.exe install osrusbfx2.inf "USB\VID_0547&PID_1002"
-
-@rem then this one, which brings the device into existence
-devcon.exe install UDEFX2.inf Root\UDEFX2

--- a/UDEFX_host/share.bat
+++ b/UDEFX_host/share.bat
@@ -1,8 +1,0 @@
-@setlocal
-mkdir %userprofile%\vmshare\usbt >nul 2>&1
-copy /y driver_both.txt %userprofile%\vmshare\usbt
-copy /y exe\x64\Debug\hostudetest.exe %userprofile%\vmshare\usbt
-copy /y driver\x64\Debug\*.sys %userprofile%\vmshare\usbt
-copy /y driver\x64\Debug\*.inf %userprofile%\vmshare\usbt
-copy /y driver\x64\Debug\*.cat %userprofile%\vmshare\usbt
-

--- a/share.bat
+++ b/share.bat
@@ -1,8 +1,0 @@
-pushd %~dp0\udefx2
-call share.bat
-popd
-pushd %~dp0\UDEFX_host
-call share.bat
-popd
-
-copy /y installem.bat %userprofile%\vmshare\usbt


### PR DESCRIPTION
Also delete the three `share.bat` scripts that directly and indirectly reference `driver_both.txt`, since they are now broken.

Alternative approach:
If you prefer, then can instead update the `share.bat` scripts to reference `installem.bat` instead of deleting them. 