### PR TITLE
Switch to PnPutil for driver installation

### DIFF
--- a/UDEFX2/UDEFX2.vcxproj
+++ b/UDEFX2/UDEFX2.vcxproj
@@ -122,7 +122,7 @@
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <PostBuildEvent>
-      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devcon.exe" $(PackageDir)
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devgen.exe" $(PackageDir)
 copy $(OutDir)\UDEFX2.cer $(PackageDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -140,7 +140,7 @@ copy $(OutDir)\UDEFX2.cer $(PackageDir)</Command>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
     <PostBuildEvent>
-      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devcon.exe" $(PackageDir)
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devgen.exe" $(PackageDir)
 copy $(OutDir)\UDEFX2.cer $(PackageDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -155,7 +155,7 @@ copy $(OutDir)\UDEFX2.cer $(PackageDir)</Command>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devcon.exe" $(PackageDir)
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devgen.exe" $(PackageDir)
 copy $(OutDir)\UDEFX2.cer $(PackageDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
@@ -170,7 +170,7 @@ copy $(OutDir)\UDEFX2.cer $(PackageDir)</Command>
       <AdditionalDependencies>$(DDK_LIB_PATH)\ude\1.0\udecxstub.lib;usbdex.lib;WdmSec.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devcon.exe" $(PackageDir)
+      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\$(Platform)\devgen.exe" $(PackageDir)
 copy $(OutDir)\UDEFX2.cer $(PackageDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/UDEFX_host/driver/hostude.vcxproj
+++ b/UDEFX_host/driver/hostude.vcxproj
@@ -114,8 +114,7 @@
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\devcon.exe" $(PackageDir)
-copy $(OutDir)\hostude.cer $(PackageDir)</Command>
+      <Command>copy $(OutDir)\hostude.cer $(PackageDir)</Command>
     </PostBuildEvent>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
@@ -127,8 +126,7 @@ copy $(OutDir)\hostude.cer $(PackageDir)</Command>
       </ExceptionHandling>
     </ClCompile>
     <PostBuildEvent>
-      <Command>copy "C:\Program Files (x86)\Windows Kits\10\tools\$(WDKBuildFolder)\x64\devcon.exe" $(PackageDir)
-copy $(OutDir)\hostude.cer $(PackageDir)</Command>
+      <Command>copy $(OutDir)\hostude.cer $(PackageDir)</Command>
     </PostBuildEvent>
     <DriverSign>
       <FileDigestAlgorithm>sha256</FileDigestAlgorithm>

--- a/installem.bat
+++ b/installem.bat
@@ -2,6 +2,9 @@
 certutil.exe -addstore root hostude.cer
 certutil.exe -addstore trustedpublisher hostude.cer
 
-devcon.exe install hostude.inf "USB\VID_1209&PID_0887"
+:: Install drivers
+pnputil.exe /add-driver hostude.inf /install
+pnputil.exe /add-driver UDEFX2.inf /install
 
-devcon.exe install UDEFX2.inf Root\UDEFX2
+:: Create SW device
+devgen.exe /add /instanceid 1 /hardwareid "Root\UDEFX2"

--- a/uninstallem.bat
+++ b/uninstallem.bat
@@ -1,0 +1,6 @@
+:: Delete SW device
+devgen.exe /remove SWD\DEVGEN\1
+
+:: Uninstall drivers
+pnputil.exe /delete-driver UDEFX2.inf /uninstall /force
+pnputil.exe /delete-driver hostude.inf /uninstall /force


### PR DESCRIPTION
Changes:
* Switch to PnpUtil for driver installation.
* Switch to DevGen for UDEFX2 SW device creation.
* Add uninstallation script for cleaning up.

This eliminates the need for the [deprecated DevCon](https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/devcon-migration) utility. DevGen is furthermore only needed for UDEFX2, and not for hostude.

I've already tested the changes in a clean Win10 VM to verify that driver installation and hostudetest.exe still works as before.