### PR TITLE
Reintroduce deleted share.bat scripts

### DIFF
--- a/UDEFX2/share.bat
+++ b/UDEFX2/share.bat
@@ -1,0 +1,7 @@
+@setlocal
+mkdir %userprofile%\vmshare\usbt >nul 2>&1
+copy /y x64\Debug\UDEFX2.sys %userprofile%\vmshare\usbt
+copy /y x64\Debug\UDEFX2.inf %userprofile%\vmshare\usbt
+copy /y x64\Debug\UDEFX2\udefx2.cat %userprofile%\vmshare\usbt
+copy /y trace\*.bat %userprofile%\vmshare\usbt
+

--- a/UDEFX_host/share.bat
+++ b/UDEFX_host/share.bat
@@ -1,0 +1,8 @@
+@setlocal
+mkdir %userprofile%\vmshare\usbt >nul 2>&1
+copy /y driver_both.txt %userprofile%\vmshare\usbt
+copy /y exe\x64\Debug\hostudetest.exe %userprofile%\vmshare\usbt
+copy /y driver\x64\Debug\*.sys %userprofile%\vmshare\usbt
+copy /y driver\x64\Debug\*.inf %userprofile%\vmshare\usbt
+copy /y driver\x64\Debug\*.cat %userprofile%\vmshare\usbt
+

--- a/UDEFX_host/share.bat
+++ b/UDEFX_host/share.bat
@@ -1,6 +1,5 @@
 @setlocal
 mkdir %userprofile%\vmshare\usbt >nul 2>&1
-copy /y driver_both.txt %userprofile%\vmshare\usbt
 copy /y exe\x64\Debug\hostudetest.exe %userprofile%\vmshare\usbt
 copy /y driver\x64\Debug\*.sys %userprofile%\vmshare\usbt
 copy /y driver\x64\Debug\*.inf %userprofile%\vmshare\usbt

--- a/share.bat
+++ b/share.bat
@@ -1,0 +1,8 @@
+pushd %~dp0\udefx2
+call share.bat
+popd
+pushd %~dp0\UDEFX_host
+call share.bat
+popd
+
+copy /y installem.bat %userprofile%\vmshare\usbt

--- a/share.bat
+++ b/share.bat
@@ -4,5 +4,3 @@ popd
 pushd %~dp0\UDEFX_host
 call share.bat
 popd
-
-copy /y installem.bat %userprofile%\vmshare\usbt


### PR DESCRIPTION
Reintroduce the deleted `share.bat` scripts with the line that refers to the deleted `driver_both.txt` file deleted. Also, remove the line that calls `installem.bat` as suggested by xxandy in #27.