### PR TITLE
Remove support for paging out certain functions - to simplify & fix Code Analysis warning

### DIFF
--- a/UDEFX2/Device.c
+++ b/UDEFX2/Device.c
@@ -23,10 +23,6 @@ Environment:
 #include <ntstrsafe.h>
 #include "device.tmh"
 
-#ifdef ALLOC_PRAGMA
-#pragma alloc_text (PAGE, UDEFX2CreateDevice)
-#endif
-
 NTSTATUS
 UDEFX2CreateDevice(
     _Inout_ PWDFDEVICE_INIT WdfDeviceInit

--- a/UDEFX2/Driver.c
+++ b/UDEFX2/Driver.c
@@ -18,12 +18,6 @@ Environment:
 #include "driver.tmh"
 
 
-#ifdef ALLOC_PRAGMA
-#pragma alloc_text (INIT, DriverEntry)
-#pragma alloc_text (PAGE, UDEFX2EvtDeviceAdd)
-#pragma alloc_text (PAGE, UDEFX2EvtDriverContextCleanup)
-#endif
-
 NTSTATUS
 DriverEntry(
     _In_ PDRIVER_OBJECT  DriverObject,
@@ -124,8 +118,6 @@ Return Value:
 
     UNREFERENCED_PARAMETER(Driver);
 
-    PAGED_CODE();
-
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Entry");
 
     status = UDEFX2CreateDevice(DeviceInit);
@@ -155,8 +147,6 @@ Return Value:
 --*/
 {
     UNREFERENCED_PARAMETER(DriverObject);
-
-    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Entry");
 

--- a/UDEFX_host/driver/Device.c
+++ b/UDEFX_host/driver/Device.c
@@ -27,14 +27,6 @@ Environment:
 
 #include "device.tmh"
 
-#ifdef ALLOC_PRAGMA
-#pragma alloc_text(PAGE, OsrFxEvtDeviceAdd)
-#pragma alloc_text(PAGE, OsrFxEvtDevicePrepareHardware)
-#pragma alloc_text(PAGE, OsrFxEvtDeviceD0Exit)
-#pragma alloc_text(PAGE, SelectInterfaces)
-#pragma alloc_text(PAGE, OsrFxSetPowerPolicy)
-#pragma alloc_text(PAGE, OsrFxValidateConfigurationDescriptor)
-#endif
 
 
 NTSTATUS
@@ -75,8 +67,6 @@ Return Value:
     DEVPROP_BOOLEAN                     isRestricted;
 
     UNREFERENCED_PARAMETER(Driver);
-
-    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP,"--> OsrFxEvtDeviceAdd routine\n");
 
@@ -444,7 +434,6 @@ Return Value:
     UNREFERENCED_PARAMETER(ResourceList);
     UNREFERENCED_PARAMETER(ResourceListTranslated);
     waitWakeEnable = FALSE;
-    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_PNP, "--> EvtDevicePrepareHardware\n");
 
@@ -668,8 +657,6 @@ Return Value:
 {
     PDEVICE_CONTEXT         pDeviceContext;
 
-    PAGED_CODE();
-
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_POWER,
           "-->OsrFxEvtDeviceD0Exit - moving to %s\n",
           DbgDevicePowerString(TargetState));
@@ -743,8 +730,6 @@ Return Value:
     USBD_STATUS status = USBD_STATUS_SUCCESS;
     USHORT ValidationLevel = 3;
 
-    PAGED_CODE();
-
     //
     // Call USBD_ValidateConfigurationDescriptor to validate the descriptors which are present in this supplied configuration descriptor.
     // USBD_ValidateConfigurationDescriptor validates that all descriptors are completely contained within the configuration descriptor buffer.
@@ -776,8 +761,6 @@ OsrFxSetPowerPolicy(
     WDF_DEVICE_POWER_POLICY_IDLE_SETTINGS idleSettings;
     WDF_DEVICE_POWER_POLICY_WAKE_SETTINGS wakeSettings;
     NTSTATUS    status = STATUS_SUCCESS;
-
-    PAGED_CODE();
 
     //
     // Init the idle policy structure.
@@ -837,8 +820,6 @@ Return Value:
     WDF_USB_PIPE_INFORMATION            pipeInfo;
     UCHAR                               index;
     UCHAR                               numberConfiguredPipes;
-
-    PAGED_CODE();
 
     pDeviceContext = GetDeviceContext(Device);
 

--- a/UDEFX_host/driver/driver.c
+++ b/UDEFX_host/driver/driver.c
@@ -45,10 +45,6 @@ Environment:
 
 PFN_IO_SET_DEVICE_INTERFACE_PROPERTY_DATA g_pIoSetDeviceInterfacePropertyData;
 
-#ifdef ALLOC_PRAGMA
-#pragma alloc_text(INIT, DriverEntry)
-#pragma alloc_text(PAGE, OsrFxEvtDriverContextCleanup)
-#endif
 
 NTSTATUS
 DriverEntry(
@@ -176,8 +172,6 @@ Return Value:
     // EvtCleanupCallback for WDFDRIVER is always called at PASSIVE_LEVEL
     //
     _IRQL_limited_to_(PASSIVE_LEVEL);
-
-    PAGED_CODE ();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_INIT,
                     "--> OsrFxEvtDriverContextCleanup\n");

--- a/UDEFX_host/driver/ioctl.c
+++ b/UDEFX_host/driver/ioctl.c
@@ -25,9 +25,6 @@ Environment:
 
 #include "ioctl.tmh"
 
-#pragma alloc_text(PAGE, OsrFxEvtIoDeviceControl)
-#pragma alloc_text(PAGE, ResetPipe)
-#pragma alloc_text(PAGE, ResetDevice)
 
 VOID
 OsrFxEvtIoDeviceControl(
@@ -77,8 +74,6 @@ Return Value:
     // at IRQL = PASSIVE_LEVEL.
     //
     _IRQL_limited_to_(PASSIVE_LEVEL);
-
-    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_IOCTL, "--> OsrFxEvtIoDeviceControl\n");
     //
@@ -226,8 +221,6 @@ Return Value:
 {
     NTSTATUS          status;
 
-    PAGED_CODE();
-
     //
     //  This routine synchronously submits a URB_FUNCTION_RESET_PIPE
     // request down the stack.
@@ -310,8 +303,6 @@ Return Value:
 {
     PDEVICE_CONTEXT pDeviceContext;
     NTSTATUS status;
-
-    PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, DBG_IOCTL, "--> ResetDevice\n");
 


### PR DESCRIPTION
Done to simplify, so that the implementation becomes slightly easier to understand for driver "newbies". Making certain functions pageable is an optimization to reduce RAM usage that does not effect the driver functionality.

Driver binary sizes:
* Release-builds of UDEFX2.sys are 33kB on my computer.
* Release-builds of hostude.sys are 26kB on my computer. 

Any RAM consumption growth is therefore guaranteed to be less than 33kb + 26kB = 59kB when both drivers are loaded. This is a negligible amount of RAM on todays computers.

I've already tested the changes with `hostudetest.exe -a`/`hostudetest.exe -c somemission` in a clean Win11 VM.

## Related documentation
* [Locking Pageable Code or Data](https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/locking-pageable-code-or-data) - mentions `#pragma alloc_text (PAGE,...)`
* [Writing a DriverEntry Routine](https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/writing-a-driverentry-routine) - mentions `#pragma alloc_text (INIT,...)`