### PR TITLE
UDEFX2: Postpone variable definitions until first use - to modernize the code

### DIFF
--- a/UDEFX2/BackChannel.c
+++ b/UDEFX2/BackChannel.c
@@ -39,12 +39,9 @@ BackChannelInit(
     _In_ WDFDEVICE ctrdevice
 )
 {
-    NTSTATUS status = STATUS_SUCCESS;
-    PUDECX_USBCONTROLLER_CONTEXT pControllerContext;
+    PUDECX_USBCONTROLLER_CONTEXT pControllerContext = GetUsbControllerContext(ctrdevice);
 
-    pControllerContext = GetUsbControllerContext(ctrdevice);
-
-    status = WRQueueInit(ctrdevice, &(pControllerContext->missionRequest), FALSE);
+    NTSTATUS status = WRQueueInit(ctrdevice, &(pControllerContext->missionRequest), FALSE);
     if (!NT_SUCCESS(status)) {
         LogError(TRACE_DEVICE, "Unable to initialize mission completion, err= %!STATUS!", status);
         goto exit;
@@ -66,9 +63,7 @@ BackChannelDestroy(
     _In_ WDFDEVICE ctrdevice
 )
 {
-    PUDECX_USBCONTROLLER_CONTEXT pControllerContext;
-
-    pControllerContext = GetUsbControllerContext(ctrdevice);
+    PUDECX_USBCONTROLLER_CONTEXT pControllerContext = GetUsbControllerContext(ctrdevice);
 
     WRQueueDestroy(&(pControllerContext->missionCompletion));
     WRQueueDestroy(&(pControllerContext->missionRequest));
@@ -81,9 +76,6 @@ BackChannelEvtRead(
     size_t     Length
 )
 {
-    WDFDEVICE controller;
-    PUDECX_USBCONTROLLER_CONTEXT pControllerContext;
-    NTSTATUS status = STATUS_SUCCESS;
     BOOLEAN bReady = FALSE;
     PVOID transferBuffer;
     SIZE_T transferBufferLength;
@@ -91,10 +83,10 @@ BackChannelEvtRead(
 
     UNREFERENCED_PARAMETER(Length);
 
-    controller = WdfIoQueueGetDevice(Queue); /// WdfIoQueueGetDevice
-    pControllerContext = GetUsbControllerContext(controller);
+    WDFDEVICE controller = WdfIoQueueGetDevice(Queue); /// WdfIoQueueGetDevice
+    PUDECX_USBCONTROLLER_CONTEXT pControllerContext = GetUsbControllerContext(controller);
 
-    status = WdfRequestRetrieveOutputBuffer(Request, 1, &transferBuffer, &transferBufferLength);
+    NTSTATUS status = WdfRequestRetrieveOutputBuffer(Request, 1, &transferBuffer, &transferBufferLength);
     if (!NT_SUCCESS(status))
     {
         LogError(TRACE_DEVICE, "BCHAN WdfRequest read %p unable to retrieve buffer %!STATUS!",
@@ -133,20 +125,17 @@ BackChannelEvtWrite(
     size_t Length
 )
 {
-    WDFDEVICE controller;
     WDFREQUEST matchingRead;
-    PUDECX_USBCONTROLLER_CONTEXT pControllerContext;
-    NTSTATUS status = STATUS_SUCCESS;
     PVOID transferBuffer;
     SIZE_T transferBufferLength;
     SIZE_T completeBytes = 0;
 
     UNREFERENCED_PARAMETER(Length);
 
-    controller = WdfIoQueueGetDevice(Queue); /// WdfIoQueueGetDevice
-    pControllerContext = GetUsbControllerContext(controller);
+    WDFDEVICE controller = WdfIoQueueGetDevice(Queue); /// WdfIoQueueGetDevice
+    PUDECX_USBCONTROLLER_CONTEXT pControllerContext = GetUsbControllerContext(controller);
 
-    status = WdfRequestRetrieveInputBuffer(Request, 1, &transferBuffer, &transferBufferLength);
+    NTSTATUS status = WdfRequestRetrieveInputBuffer(Request, 1, &transferBuffer, &transferBufferLength);
     if (!NT_SUCCESS(status))
     {
         LogError(TRACE_DEVICE, "BCHAN WdfRequest write %p unable to retrieve buffer %!STATUS!",
@@ -208,9 +197,8 @@ BackChannelIoctl(
     NTSTATUS status;
     PDEVICE_INTR_FLAGS pflags = 0;
     size_t pblen;
-    PUDECX_USBCONTROLLER_CONTEXT pControllerContext;
 
-    pControllerContext = GetUsbControllerContext(ctrdevice);
+    PUDECX_USBCONTROLLER_CONTEXT pControllerContext = GetUsbControllerContext(ctrdevice);
 
 
     switch (IoControlCode)

--- a/UDEFX2/Device.c
+++ b/UDEFX2/Device.c
@@ -49,13 +49,9 @@ Return Value:
 
 --*/
 {
-	NTSTATUS                            status;
 	WDFDEVICE                           wdfDevice;
-	WDF_PNPPOWER_EVENT_CALLBACKS        wdfPnpPowerCallbacks;
 	WDF_OBJECT_ATTRIBUTES               wdfDeviceAttributes;
-	WDF_OBJECT_ATTRIBUTES               wdfRequestAttributes;
 	UDECX_WDF_DEVICE_CONFIG             controllerConfig;
-	WDF_FILEOBJECT_CONFIG               fileConfig;
     PUDECX_USBCONTROLLER_CONTEXT        pControllerContext;
 	WDF_IO_QUEUE_CONFIG                 defaultQueueConfig;
 	WDF_DEVICE_POWER_POLICY_IDLE_SETTINGS
@@ -64,6 +60,7 @@ Return Value:
 
 	FuncEntry(TRACE_DEVICE);
 
+	WDF_PNPPOWER_EVENT_CALLBACKS wdfPnpPowerCallbacks;
 	WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&wdfPnpPowerCallbacks);
 	wdfPnpPowerCallbacks.EvtDevicePrepareHardware = ControllerWdfEvtDevicePrepareHardware;
 	wdfPnpPowerCallbacks.EvtDeviceReleaseHardware = ControllerWdfEvtDeviceReleaseHardware;
@@ -76,6 +73,7 @@ Return Value:
 
 	WdfDeviceInitSetPnpPowerEventCallbacks(WdfDeviceInit, &wdfPnpPowerCallbacks);
 
+	WDF_OBJECT_ATTRIBUTES wdfRequestAttributes;
 	WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&wdfRequestAttributes, REQUEST_CONTEXT);
 	WdfDeviceInitSetRequestAttributes(WdfDeviceInit, &wdfRequestAttributes);
 
@@ -84,6 +82,7 @@ Return Value:
 	// interface reference strings. This requires calling WdfDeviceInitSetFileObjectConfig
 	// with FileObjectClass WdfFileObjectWdfXxx.
 	//
+	WDF_FILEOBJECT_CONFIG fileConfig;
 	WDF_FILEOBJECT_CONFIG_INIT(&fileConfig,
 		WDF_NO_EVENT_CALLBACK,
 		WDF_NO_EVENT_CALLBACK,
@@ -103,7 +102,7 @@ Return Value:
 	//
 	// Set the security descriptor for the device.
 	//
-	status = WdfDeviceInitAssignSDDLString(WdfDeviceInit, &SDDL_DEVOBJ_SYS_ALL_ADM_RWX_WORLD_RW_RES_R);
+	NTSTATUS status = WdfDeviceInitAssignSDDLString(WdfDeviceInit, &SDDL_DEVOBJ_SYS_ALL_ADM_RWX_WORLD_RW_RES_R);
 
 	if (!NT_SUCCESS(status)) {
 
@@ -289,7 +288,6 @@ NTSTATUS
 {
 	NTSTATUS status;
 	UINT32 instanceNumber;
-	BOOLEAN isCreated;
 
 	DECLARE_UNICODE_STRING_SIZE(uniDeviceName, DeviceNameSize);
 	DECLARE_UNICODE_STRING_SIZE(uniSymLinkName, SymLinkNameSize);
@@ -301,7 +299,7 @@ NTSTATUS
 	// Generate a unique static device name in order to provide compatibility to look like with
 	// existing USB host controller driver implementations.
 	//
-	isCreated = FALSE;
+	BOOLEAN isCreated = FALSE;
 
 	for (instanceNumber = 0; instanceNumber < MAXUINT32; instanceNumber++) {
 
@@ -416,10 +414,9 @@ ControllerWdfEvtDeviceD0Entry(
 )
 {
 	NTSTATUS status = STATUS_SUCCESS;
-    PUDECX_USBCONTROLLER_CONTEXT pControllerContext;
 
 	FuncEntry(TRACE_DEVICE);
-	pControllerContext = GetUsbControllerContext(WdfDevice);
+	PUDECX_USBCONTROLLER_CONTEXT pControllerContext = GetUsbControllerContext(WdfDevice);
 
 	if (PreviousState == WdfPowerDeviceD3Final) {
 
@@ -532,15 +529,13 @@ ControllerEvtIoDeviceControl(
 	_In_ ULONG IoControlCode
 )
 {
-	BOOLEAN handled;
-    NTSTATUS status = STATUS_SUCCESS;
     WDFDEVICE ctrdevice = WdfIoQueueGetDevice(Queue);
 
     
     UNREFERENCED_PARAMETER(OutputBufferLength);
 	UNREFERENCED_PARAMETER(InputBufferLength);
 
-	handled = UdecxWdfDeviceTryHandleUserIoctl(ctrdevice,
+	BOOLEAN handled = UdecxWdfDeviceTryHandleUserIoctl(ctrdevice,
 		Request);
 
 	if (handled) {
@@ -555,7 +550,7 @@ ControllerEvtIoDeviceControl(
     }
 
 
-	status = STATUS_INVALID_DEVICE_REQUEST;
+	NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
 	LogError(TRACE_DEVICE, "Unexpected I/O control code 0x%x %!STATUS!", IoControlCode, status);
 	NT_ASSERTMSG("Unexpected I/O", FALSE);
 	WdfRequestComplete(Request, status);

--- a/UDEFX2/Driver.c
+++ b/UDEFX2/Driver.c
@@ -55,10 +55,6 @@ Return Value:
 
 --*/
 {
-    WDF_DRIVER_CONFIG config;
-    NTSTATUS status;
-    WDF_OBJECT_ATTRIBUTES attributes;
-
     //
     // Initialize WPP Tracing
     //
@@ -70,15 +66,17 @@ Return Value:
     // Register a cleanup callback so that we can call WPP_CLEANUP when
     // the framework driver object is deleted during driver unload.
     //
+    WDF_OBJECT_ATTRIBUTES attributes;
     WDF_OBJECT_ATTRIBUTES_INIT(&attributes);
     attributes.EvtCleanupCallback = UDEFX2EvtDriverContextCleanup;
 
+    WDF_DRIVER_CONFIG config;
     WDF_DRIVER_CONFIG_INIT(&config,
                            UDEFX2EvtDeviceAdd
                            );
 	config.DriverPoolTag = UDEFX_POOL_TAG;
 
-    status = WdfDriverCreate(DriverObject,
+    NTSTATUS status = WdfDriverCreate(DriverObject,
                              RegistryPath,
                              &attributes,
                              &config,
@@ -120,15 +118,13 @@ Return Value:
 
 --*/
 {
-    NTSTATUS status;
-
     UNREFERENCED_PARAMETER(Driver);
 
     PAGED_CODE();
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Entry");
 
-    status = UDEFX2CreateDevice(DeviceInit);
+    NTSTATUS status = UDEFX2CreateDevice(DeviceInit);
 
     TraceEvents(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "%!FUNC! Exit");
 

--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -151,24 +151,18 @@ Usb_Initialize(
     _In_ WDFDEVICE WdfDevice
 )
 {
-    NTSTATUS                                status;
-    PUDECX_USBCONTROLLER_CONTEXT            controllerContext;
-    UDECX_USB_DEVICE_STATE_CHANGE_CALLBACKS   callbacks;
-
-
-
     //
     // Allocate per-controller private contexts used by other source code modules (I/O,
     // etc.)
     //
 
-
-    controllerContext = GetUsbControllerContext(WdfDevice);
+    PUDECX_USBCONTROLLER_CONTEXT controllerContext = GetUsbControllerContext(WdfDevice);
 
     UsbValidateConstants();
 
     controllerContext->ChildDeviceInit = UdecxUsbDeviceInitAllocate(WdfDevice);
 
+    NTSTATUS status;
     if (controllerContext->ChildDeviceInit == NULL) {
 
         status = STATUS_INSUFFICIENT_RESOURCES;
@@ -179,6 +173,7 @@ Usb_Initialize(
     //
     // State changed callbacks
     //
+    UDECX_USB_DEVICE_STATE_CHANGE_CALLBACKS callbacks;
     UDECX_USB_DEVICE_CALLBACKS_INIT(&callbacks);
 
     callbacks.EvtUsbDeviceLinkPowerEntry = UsbDevice_EvtUsbDeviceLinkPowerEntry;
@@ -245,7 +240,6 @@ Usb_Initialize(
     //
 
 exit:
-
     //
     // On failure in this function (or later but still before creating the UDECXUSBDEVICE),
     // UdecxUsbDeviceInit will be freed by Usb_Destroy.
@@ -264,19 +258,12 @@ Usb_ReadDescriptorsAndPlugIn(
 )
 {
     NTSTATUS                          status;
-    PUSB_CONFIGURATION_DESCRIPTOR     pComputedConfigDescSet;
-    WDF_OBJECT_ATTRIBUTES             attributes;
-    PUDECX_USBCONTROLLER_CONTEXT      controllerContext;
-    PUSB_CONTEXT                      deviceContext = NULL;
-    UDECX_USB_DEVICE_PLUG_IN_OPTIONS  pluginOptions;
-
-    controllerContext = GetUsbControllerContext(WdfControllerDevice);
-    pComputedConfigDescSet = NULL;
+    PUDECX_USBCONTROLLER_CONTEXT controllerContext = GetUsbControllerContext(WdfControllerDevice);
 
     //
     // Compute configuration descriptor dynamically.
     //
-    pComputedConfigDescSet = (PUSB_CONFIGURATION_DESCRIPTOR)
+    PUSB_CONFIGURATION_DESCRIPTOR pComputedConfigDescSet = (PUSB_CONFIGURATION_DESCRIPTOR)
         ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(g_UsbConfigDescriptorSet), UDECXMBIM_POOL_TAG);
 
     if (pComputedConfigDescSet == NULL) {
@@ -304,6 +291,7 @@ Usb_ReadDescriptorsAndPlugIn(
     //
     // Create emulated USB device
     //
+    WDF_OBJECT_ATTRIBUTES attributes;
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&attributes, USB_CONTEXT);
 
     status = UdecxUsbDeviceCreate(&controllerContext->ChildDeviceInit,
@@ -323,7 +311,7 @@ Usb_ReadDescriptorsAndPlugIn(
     }
 
 
-    deviceContext = GetUsbDeviceContext(controllerContext->ChildDevice);
+    PUSB_CONTEXT deviceContext = GetUsbDeviceContext(controllerContext->ChildDevice);
 
     // create link to parent
     deviceContext->ControllerDevice = WdfControllerDevice;
@@ -376,6 +364,7 @@ Usb_ReadDescriptorsAndPlugIn(
     //
     // This begins USB communication and prevents us from modifying descriptors and simple endpoints.
     //
+    UDECX_USB_DEVICE_PLUG_IN_OPTIONS pluginOptions;
     UDECX_USB_DEVICE_PLUG_IN_OPTIONS_INIT(&pluginOptions);
     pluginOptions.Usb20PortNumber = 1;
     status = UdecxUsbDevicePlugIn(controllerContext->ChildDevice, &pluginOptions);
@@ -402,16 +391,12 @@ Usb_Disconnect(
     _In_  WDFDEVICE WdfDevice
 )
 {
-    NTSTATUS status;
-    PUDECX_USBCONTROLLER_CONTEXT controllerCtx;
+    PUDECX_USBCONTROLLER_CONTEXT controllerCtx = GetUsbControllerContext(WdfDevice);
+
     IO_CONTEXT ioContextCopy;
-
-
-    controllerCtx = GetUsbControllerContext(WdfDevice);
-
     Io_StopDeferredProcessing(controllerCtx->ChildDevice, &ioContextCopy);
 
-    status = UdecxUsbDevicePlugOutAndDelete(controllerCtx->ChildDevice);
+    NTSTATUS status = UdecxUsbDevicePlugOutAndDelete(controllerCtx->ChildDevice);
     // Not deleting the queues that belong to the controller, as this
     // happens only in the last disconnect.  But if we were to connect again,
     // we would need to do that as the queues would leak.
@@ -436,9 +421,7 @@ Usb_Destroy(
     _In_ WDFDEVICE WdfDevice
 )
 {
-    PUDECX_USBCONTROLLER_CONTEXT pControllerContext;
-
-    pControllerContext = GetUsbControllerContext(WdfDevice);
+    PUDECX_USBCONTROLLER_CONTEXT pControllerContext = GetUsbControllerContext(WdfDevice);
 
     //
     // Free device init in case we didn't successfully create the device.
@@ -476,17 +459,11 @@ UsbCreateEndpointObj(
     _Out_  UDECXUSBENDPOINT *pNewEpObjAddr
 )
 {
-    NTSTATUS                      status;
-    PUSB_CONTEXT                  pUsbContext;
-    WDFQUEUE                      epQueue;
-    UDECX_USB_ENDPOINT_CALLBACKS  callbacks;
-    PUDECXUSBENDPOINT_INIT        endpointInit;
+    PUSB_CONTEXT pUsbContext = GetUsbDeviceContext(WdfUsbChildDevice);
+    PUDECXUSBENDPOINT_INIT endpointInit = NULL;
 
-
-    pUsbContext = GetUsbDeviceContext(WdfUsbChildDevice);
-    endpointInit = NULL;
-
-    status = Io_RetrieveEpQueue(WdfUsbChildDevice, epAddr, &epQueue);
+    WDFQUEUE epQueue;
+    NTSTATUS status = Io_RetrieveEpQueue(WdfUsbChildDevice, epAddr, &epQueue);
 
     if (!NT_SUCCESS(status)) {
         goto exit;
@@ -503,6 +480,7 @@ UsbCreateEndpointObj(
 
     UdecxUsbEndpointInitSetEndpointAddress(endpointInit, epAddr);
 
+    UDECX_USB_ENDPOINT_CALLBACKS callbacks;
     UDECX_USB_ENDPOINT_CALLBACKS_INIT(&callbacks, UsbEndpointReset);
     UdecxUsbEndpointInitSetCallbacks(endpointInit, &callbacks);
 
@@ -564,10 +542,9 @@ UsbDevice_EvtUsbDeviceLinkPowerEntry(
     _In_ WDFDEVICE       UdecxWdfDevice,
     _In_ UDECXUSBDEVICE    UdecxUsbDevice )
 {
-    PUSB_CONTEXT pUsbContext;
     UNREFERENCED_PARAMETER(UdecxWdfDevice);
 
-    pUsbContext = GetUsbDeviceContext(UdecxUsbDevice);
+    PUSB_CONTEXT pUsbContext = GetUsbDeviceContext(UdecxUsbDevice);
     Io_DeviceWokeUp(UdecxUsbDevice);
     pUsbContext->IsAwake = TRUE;
     LogInfo(TRACE_DEVICE, "USB Device power ENTRY");
@@ -581,10 +558,9 @@ UsbDevice_EvtUsbDeviceLinkPowerExit(
     _In_ UDECXUSBDEVICE UdecxUsbDevice,
     _In_ UDECX_USB_DEVICE_WAKE_SETTING WakeSetting )
 {
-    PUSB_CONTEXT pUsbContext;
     UNREFERENCED_PARAMETER(UdecxWdfDevice);
 
-    pUsbContext = GetUsbDeviceContext(UdecxUsbDevice);
+    PUSB_CONTEXT pUsbContext = GetUsbDeviceContext(UdecxUsbDevice);
     pUsbContext->IsAwake = FALSE;
 
     Io_DeviceSlept(UdecxUsbDevice);
@@ -611,8 +587,3 @@ UsbDevice_EvtUsbDeviceSetFunctionSuspendAndWake(
 
     return STATUS_SUCCESS;
 }
-
-
-
-
-

--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -459,7 +459,6 @@ UsbCreateEndpointObj(
     _Out_  UDECXUSBENDPOINT *pNewEpObjAddr
 )
 {
-    PUSB_CONTEXT pUsbContext = GetUsbDeviceContext(WdfUsbChildDevice);
     PUDECXUSBENDPOINT_INIT endpointInit = NULL;
 
     WDFQUEUE epQueue;


### PR DESCRIPTION
The changes are only done partially in functions with goto. I'll probably need to switch to C++ with RAII some wrapper-classes to be able to completely postpone all variable definitions until first use.

### Motivation
* Improves readability and maintainability.
* Have been supported since C99.
* Can potentially _reduce_ stack size usage when variable usage is confined to a local scope. The compiler is probably already optimizing this though.

### Downside
* It's a bit more cumbersome to manually determine the stack size of a function when all local variables are no longer listed together.

I've already tested the changes with `hostudetest.exe -a`/`hostudetest.exe -c somemission` in a clean Win11 VM.