### PR TITLE
UDEFX2: Convert g_UsbDeviceDescriptor type to USB_DEVICE_DESCRIPTOR 

### DIFF
--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -37,19 +37,17 @@ const UCHAR g_LanguageDescriptor[] = { 4,3,9,4 };
 
 
 
-const UCHAR g_UsbDeviceDescriptor[18] =
-{
-    0x12,                            // Descriptor size
+const USB_DEVICE_DESCRIPTOR g_UsbDeviceDescriptor = {
+    sizeof(USB_DEVICE_DESCRIPTOR),   // Descriptor size
     USB_DEVICE_DESCRIPTOR_TYPE,      // Device descriptor type
-    0x00, 0x02,                      // USB 2.0
+    0x0200,                          // USB 2.0
     0x00,                            // Device class (interface-class defined)
     0x00,                            // Device subclass
     0x00,                            // Device protocol
     0x40,                            // Maxpacket size for EP0
     UDEFX2_DEVICE_VENDOR_ID,         // Vendor ID
     UDEFX2_DEVICE_PROD_ID,           // Product ID
-    0x00,                            // LSB of firmware revision
-    0x01,                            // MSB of firmware revision
+    0x0100,                          // firmware revision
     g_ManufacturerIndex,             // Manufacture string index
     g_ProductIndex,                  // Product string index
     0x00,                            // Serial number string index
@@ -120,19 +118,12 @@ UsbValidateConstants(
     //
     NT_ASSERT(((PUSB_STRING_DESCRIPTOR)g_LanguageDescriptor)->bString[0] == AMERICAN_ENGLISH);
     //NT_ASSERT(((PUSB_STRING_DESCRIPTOR)g_LanguageDescriptor)->bString[1] == PRC_CHINESE);
-    NT_ASSERT(((PUSB_DEVICE_DESCRIPTOR)g_UsbDeviceDescriptor)->iManufacturer == g_ManufacturerIndex);
-    NT_ASSERT(((PUSB_DEVICE_DESCRIPTOR)g_UsbDeviceDescriptor)->iProduct == g_ProductIndex);
 
-    NT_ASSERT(((PUSB_DEVICE_DESCRIPTOR)g_UsbDeviceDescriptor)->bLength ==
-        sizeof(USB_DEVICE_DESCRIPTOR));
-    NT_ASSERT(sizeof(g_UsbDeviceDescriptor) == sizeof(USB_DEVICE_DESCRIPTOR));
     NT_ASSERT(((PUSB_CONFIGURATION_DESCRIPTOR)g_UsbConfigDescriptorSet)->wTotalLength ==
         sizeof(g_UsbConfigDescriptorSet));
     NT_ASSERT(((PUSB_STRING_DESCRIPTOR)g_LanguageDescriptor)->bLength ==
         sizeof(g_LanguageDescriptor));
 
-    NT_ASSERT(((PUSB_DEVICE_DESCRIPTOR)g_UsbDeviceDescriptor)->bDescriptorType ==
-        USB_DEVICE_DESCRIPTOR_TYPE);
     NT_ASSERT(((PUSB_CONFIGURATION_DESCRIPTOR)g_UsbConfigDescriptorSet)->bDescriptorType ==
         USB_CONFIGURATION_DESCRIPTOR_TYPE);
     NT_ASSERT(((PUSB_STRING_DESCRIPTOR)g_LanguageDescriptor)->bDescriptorType ==
@@ -198,7 +189,7 @@ Usb_Initialize(
     // Device descriptor
     //
     status = UdecxUsbDeviceInitAddDescriptor(controllerContext->ChildDeviceInit,
-        (PUCHAR)g_UsbDeviceDescriptor,
+        (PUCHAR)&g_UsbDeviceDescriptor,
         sizeof(g_UsbDeviceDescriptor));
 
     if (!NT_SUCCESS(status)) {

--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -50,8 +50,8 @@ const UCHAR g_UsbDeviceDescriptor[18] =
     UDEFX2_DEVICE_PROD_ID,           // Product ID
     0x00,                            // LSB of firmware revision
     0x01,                            // MSB of firmware revision
-    0x01,                            // Manufacture string index
-    0x02,                            // Product string index
+    g_ManufacturerIndex,             // Manufacture string index
+    g_ProductIndex,                  // Product string index
     0x00,                            // Serial number string index
     0x01                             // Number of configurations
 };

--- a/UDEFX2/usbdevice.h
+++ b/UDEFX2/usbdevice.h
@@ -54,10 +54,9 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(USB_CONTEXT, GetUsbDeviceContext);
 #define g_InterruptEndpointAddress 0x86
 
 
-#define UDEFX2_DEVICE_VENDOR_ID  0x9, 0x12 // little endian
-#define UDEFX2_DEVICE_PROD_ID    0x87, 0x8 // little endian
+#define UDEFX2_DEVICE_VENDOR_ID  0x1209
+#define UDEFX2_DEVICE_PROD_ID    0x0887
 
-extern const UCHAR g_UsbDeviceDescriptor[];
 extern const UCHAR g_UsbConfigDescriptorSet[];
 
 // ------------------------------------------------


### PR DESCRIPTION
Follow-up to #36.

It's safer to work directly with typed data instead of bytes-arrays. Remove associated NT_ASSERT checks that are now redundant, since they are checking obviously correct struct members.


Visual evidence that the USB device descriptor is unchanged:
![image](https://github.com/xxandy/USB_UDE_Sample/assets/2671400/da4a4080-08c8-45e3-87c9-ae3607c09095)

![image](https://github.com/xxandy/USB_UDE_Sample/assets/2671400/d681b3a5-d592-4e09-a3b9-5a59e9a558ea)

[USB Device Viewer](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/usbview) is usually found in `C:\Program Files (x86)\Windows Kits\10\Debuggers\x64`