### PR TITLE
Initialize ResultLength to fix code analysis warning

### DIFF
--- a/UDEFX2/Device.c
+++ b/UDEFX2/Device.c
@@ -572,7 +572,8 @@ ControllerEvtUdecxWdfDeviceQueryUsbCapability(
 	UNREFERENCED_PARAMETER(CapabilityType);
 	UNREFERENCED_PARAMETER(OutputBufferLength);
 	UNREFERENCED_PARAMETER(OutputBuffer);
-	UNREFERENCED_PARAMETER(ResultLength);
+
+	(*ResultLength) = 0;
 
 	if (RtlCompareMemory(
 		CapabilityType,


### PR DESCRIPTION
Fixes the following warning when running Code Analysis from Visual Studio:
`USB_UDE_Sample\UDEFX2\Device.c(571): warning C6101: Returning uninitialized memory '*ResultLength'.  A successful path through the function does not set the named _Out_ parameter.`