### PR TITLE
Update WRQueuePullRead SAL annotation to fix Code Analysis warning

### DIFF
--- a/UDEFX2/Misc.c
+++ b/UDEFX2/Misc.c
@@ -177,7 +177,7 @@ NTSTATUS
 WRQueuePullRead(
     _In_  PWRITE_BUFFER_TO_READ_REQUEST_QUEUE pQ,
     _In_  WDFREQUEST rqRead,
-    _Out_ PVOID rbuffer,
+    _Out_writes_bytes_to_opt_(rlen, *completedBytes) PVOID rbuffer,
     _In_  SIZE_T rlen,
     _Out_ PBOOLEAN pbReadyToComplete,
     _Out_ PSIZE_T completedBytes

--- a/UDEFX2/Misc.h
+++ b/UDEFX2/Misc.h
@@ -65,7 +65,7 @@ NTSTATUS
 WRQueuePullRead(
     _In_  PWRITE_BUFFER_TO_READ_REQUEST_QUEUE pQ,
     _In_  WDFREQUEST rqRead,
-    _Out_ PVOID rbuffer,
+    _Out_writes_bytes_to_opt_(rlen, *completedBytes) PVOID rbuffer,
     _In_  SIZE_T rlen,
     _Out_ PBOOLEAN pbReadyToComplete,
     _Out_ PSIZE_T completedBytes


### PR DESCRIPTION
Fixes #41.

Update SAL annotation to express that the `rbuffer` argument:
* Might be NULL.
* Is of size `rlen` where only the first `*completedBytes` bytes are written to.

Fixes the following Visual Studio Code Analysis warning:
`UDEFX2\Misc.c(177): warning C6101: Returning uninitialized memory '*rbuffer'.  A successful path through the function does not set the named _Out_ parameter.`

Documentation: [Annotating function parameters and return values](https://learn.microsoft.com/en-us/cpp/code-quality/annotating-function-parameters-and-return-values)