### PR TITLE
UDEFX2: Replace hardcoded USB descriptor sizes with sizeof(..)

### DIFF
--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -57,7 +57,7 @@ const USB_DEVICE_DESCRIPTOR g_UsbDeviceDescriptor = {
 const UCHAR g_UsbConfigDescriptorSet[] =
 {
     // Configuration Descriptor Type
-    0x9,                              // Descriptor Size
+    sizeof(USB_CONFIGURATION_DESCRIPTOR),// Descriptor Size
     USB_CONFIGURATION_DESCRIPTOR_TYPE, // Configuration Descriptor Type
     0x27, 0x00,                        // Length of this descriptor and all sub descriptors
     0x1,                               // Number of interfaces
@@ -67,8 +67,8 @@ const UCHAR g_UsbConfigDescriptorSet[] =
     0x32,                              // Max power consumption of device (in 2mA unit) : 0 ma
 
         // Interface  descriptor
-        0x9,                                      // Descriptor size
-        USB_INTERFACE_DESCRIPTOR_TYPE,             // Interface Association Descriptor Type
+        sizeof(USB_INTERFACE_DESCRIPTOR),         // Descriptor size
+        USB_INTERFACE_DESCRIPTOR_TYPE,            // Interface Association Descriptor Type
         0,                                        // bInterfaceNumber
         0,                                        // bAlternateSetting
         3,                                        // bNumEndpoints
@@ -78,7 +78,7 @@ const UCHAR g_UsbConfigDescriptorSet[] =
         0x00,                                     // iInterface
 
         // Bulk Out Endpoint descriptor
-        0x07,                           // Descriptor size
+        sizeof(USB_ENDPOINT_DESCRIPTOR),// Descriptor size
         USB_ENDPOINT_DESCRIPTOR_TYPE,   // bDescriptorType
         g_BulkOutEndpointAddress,       // bEndpointAddress
         USB_ENDPOINT_TYPE_BULK,         // bmAttributes - bulk
@@ -86,7 +86,7 @@ const UCHAR g_UsbConfigDescriptorSet[] =
         0x00,                           // bInterval
 
         // Bulk IN endpoint descriptor
-        0x07,                           // Descriptor size 
+        sizeof(USB_ENDPOINT_DESCRIPTOR),// Descriptor size 
         USB_ENDPOINT_DESCRIPTOR_TYPE,   // Descriptor type
         g_BulkInEndpointAddress,        // Endpoint address and description
         USB_ENDPOINT_TYPE_BULK,         // bmAttributes - bulk
@@ -94,7 +94,7 @@ const UCHAR g_UsbConfigDescriptorSet[] =
         0x00,                           // Servicing interval for data transfers : NA for bulk
 
         // Interrupt IN endpoint descriptor
-        0x07,                           // Descriptor size 
+        sizeof(USB_ENDPOINT_DESCRIPTOR),// Descriptor size 
         USB_ENDPOINT_DESCRIPTOR_TYPE,   // Descriptor type
         g_InterruptEndpointAddress,     // Endpoint address and description
         USB_ENDPOINT_TYPE_INTERRUPT,    // bmAttributes - interrupt

--- a/UDEFX2/usbdevice.h
+++ b/UDEFX2/usbdevice.h
@@ -38,14 +38,6 @@ typedef struct _USB_CONTEXT {
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(USB_CONTEXT, GetUsbDeviceContext);
 
 
-
-
-
-
-
-
-
-
 // ----- descriptor constants/strings/indexes
 #define g_ManufacturerIndex   1
 #define g_ProductIndex        2
@@ -57,14 +49,7 @@ WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(USB_CONTEXT, GetUsbDeviceContext);
 #define UDEFX2_DEVICE_VENDOR_ID  0x1209
 #define UDEFX2_DEVICE_PROD_ID    0x0887
 
-extern const UCHAR g_UsbConfigDescriptorSet[];
-
 // ------------------------------------------------
-
-
-
-
-
 
 
 EXTERN_C_START


### PR DESCRIPTION
Done to reduce the a amount of "magic" values in the implementation, and make the code easier to follow. Also, remove `g_UsbDeviceDescriptor` from header, since it's not references in any other source file.

Visual evidence that it's safe to replace `0x9`, `0x9` and `0x7` with `sizeof(..)`: (Visual Studio tooltips):
![image](https://github.com/xxandy/USB_UDE_Sample/assets/2671400/49e6107b-4c02-4832-bcb0-d8aab3ec6dcc)
![image](https://github.com/xxandy/USB_UDE_Sample/assets/2671400/452c81a6-c3be-46fe-a2d6-c02d014a726c)
![image](https://github.com/xxandy/USB_UDE_Sample/assets/2671400/2bce1531-0459-4b8a-9e78-c97c81481c5f)
 