### PR TITLE
UDEFX2: Replace custom MINLEN macro with min in ntdef.h

### DIFF
--- a/UDEFX2/BackChannel.c
+++ b/UDEFX2/BackChannel.c
@@ -164,7 +164,7 @@ BackChannelEvtWrite(
                 matchingRead, status);
         }
         else {
-            completeBytes = MINLEN(rlen, transferBufferLength);
+            completeBytes = min(rlen, transferBufferLength);
             memcpy(rbuffer, transferBuffer, completeBytes);
         }
 

--- a/UDEFX2/Misc.c
+++ b/UDEFX2/Misc.c
@@ -217,7 +217,7 @@ WRQueuePullRead(
         size_t minlen;
         PBUFFER_CONTENT pWriteEntry = CONTAINING_RECORD(firstPendingWrite, BUFFER_CONTENT, BufferLink);
 
-        minlen = MINLEN(pWriteEntry->BufferLength, rlen);
+        minlen = min(pWriteEntry->BufferLength, rlen);
         memcpy(rbuffer, &(pWriteEntry->BufferStart), minlen);
 
         (*pbReadyToComplete) = TRUE;

--- a/UDEFX2/Misc.h
+++ b/UDEFX2/Misc.h
@@ -17,10 +17,6 @@ Abstract:
 #include "trace.h"
 
 
-
-#define MINLEN(__a, __b)  ( ((__a) < (__b)) ? (__a) : (__b) )
-
-
 EXTERN_C_START
 
 

--- a/UDEFX2/USBCom.c
+++ b/UDEFX2/USBCom.c
@@ -186,7 +186,7 @@ IoEvtBulkOutUrb(
             LogError(TRACE_DEVICE, "WdfRequest %p cannot retrieve mission completion buffer %!STATUS!",
                 matchingRead, status);
         } else  {
-            completeBytes = MINLEN(rlen, transferBufferLength);
+            completeBytes = min(rlen, transferBufferLength);
             memcpy(rbuffer, transferBuffer, completeBytes);
         }
 


### PR DESCRIPTION
The in-built `<ntdef.h>` header already contains the following identical define:
```
#ifndef min
#define min(a,b) (((a) < (b)) ? (a) : (b))
#endif
```