### PR TITLE
UDEFX2: Delete unused PnP & USB callbacks

### DIFF
--- a/UDEFX2/Device.c
+++ b/UDEFX2/Device.c
@@ -58,14 +58,8 @@ Return Value:
 
 	WDF_PNPPOWER_EVENT_CALLBACKS wdfPnpPowerCallbacks;
 	WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&wdfPnpPowerCallbacks);
-	wdfPnpPowerCallbacks.EvtDevicePrepareHardware = ControllerWdfEvtDevicePrepareHardware;
-	wdfPnpPowerCallbacks.EvtDeviceReleaseHardware = ControllerWdfEvtDeviceReleaseHardware;
 	wdfPnpPowerCallbacks.EvtDeviceD0Entry = ControllerWdfEvtDeviceD0Entry;
 	wdfPnpPowerCallbacks.EvtDeviceD0Exit = ControllerWdfEvtDeviceD0Exit;
-	wdfPnpPowerCallbacks.EvtDeviceD0EntryPostInterruptsEnabled =
-		ControllerWdfEvtDeviceD0EntryPostInterruptsEnabled;
-	wdfPnpPowerCallbacks.EvtDeviceD0ExitPreInterruptsDisabled =
-		ControllerWdfEvtDeviceD0ExitPreInterruptsDisabled;
 
 	WdfDeviceInitSetPnpPowerEventCallbacks(WdfDeviceInit, &wdfPnpPowerCallbacks);
 
@@ -378,29 +372,6 @@ exit:
 }
 
 
-
-NTSTATUS
-ControllerWdfEvtDevicePrepareHardware(
-	_In_
-	WDFDEVICE       WdfDevice,
-	_In_
-	WDFCMRESLIST    WdfResourcesRaw,
-	_In_
-	WDFCMRESLIST    WdfResourcesTranslated
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(WdfResourcesRaw);
-	UNREFERENCED_PARAMETER(WdfResourcesTranslated);
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-
-
-
 NTSTATUS
 ControllerWdfEvtDeviceD0Entry(
 	_In_
@@ -434,38 +405,6 @@ exit:
 
 
 NTSTATUS
-ControllerWdfEvtDeviceD0EntryPostInterruptsEnabled(
-	_In_
-	WDFDEVICE              WdfDevice,
-	_In_
-	WDF_POWER_DEVICE_STATE PreviousState
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(PreviousState);
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-NTSTATUS
-ControllerWdfEvtDeviceD0ExitPreInterruptsDisabled(
-	_In_
-	WDFDEVICE              WdfDevice,
-	_In_
-	WDF_POWER_DEVICE_STATE TargetState
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(TargetState);
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-NTSTATUS
 ControllerWdfEvtDeviceD0Exit(
 	_In_ WDFDEVICE              WdfDevice,
 	_In_ WDF_POWER_DEVICE_STATE TargetState
@@ -478,23 +417,6 @@ ControllerWdfEvtDeviceD0Exit(
 		Usb_Disconnect(WdfDevice);
 	}
 
-	FuncExit(TRACE_DEVICE, 0);
-	return STATUS_SUCCESS;
-}
-
-
-
-NTSTATUS
-ControllerWdfEvtDeviceReleaseHardware(
-	_In_
-	WDFDEVICE       WdfDevice,
-	_In_
-	WDFCMRESLIST    WdfResourcesTranslated
-)
-{
-	FuncEntry(TRACE_DEVICE);
-	UNREFERENCED_PARAMETER(WdfDevice);
-	UNREFERENCED_PARAMETER(WdfResourcesTranslated);
 	FuncExit(TRACE_DEVICE, 0);
 	return STATUS_SUCCESS;
 }

--- a/UDEFX2/Device.h
+++ b/UDEFX2/Device.h
@@ -78,12 +78,8 @@ UDEFX2CreateDevice(
 
 
 
-EVT_WDF_DEVICE_PREPARE_HARDWARE                 ControllerWdfEvtDevicePrepareHardware;
-EVT_WDF_DEVICE_RELEASE_HARDWARE                 ControllerWdfEvtDeviceReleaseHardware;
 EVT_WDF_DEVICE_D0_ENTRY                         ControllerWdfEvtDeviceD0Entry;
 EVT_WDF_DEVICE_D0_EXIT                          ControllerWdfEvtDeviceD0Exit;
-EVT_WDF_DEVICE_D0_ENTRY_POST_INTERRUPTS_ENABLED ControllerWdfEvtDeviceD0EntryPostInterruptsEnabled;
-EVT_WDF_DEVICE_D0_EXIT_PRE_INTERRUPTS_DISABLED  ControllerWdfEvtDeviceD0ExitPreInterruptsDisabled;
 EVT_WDF_OBJECT_CONTEXT_CLEANUP                  ControllerWdfEvtCleanupCallback;
 EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL              ControllerEvtIoDeviceControl;
 

--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -426,21 +426,6 @@ Usb_Destroy(
     return;
 }
 
-VOID
-Usb_UdecxUsbEndpointEvtReset(
-    _In_ UCXCONTROLLER ctrl,
-    _In_ UCXENDPOINT ep,
-    _In_ WDFREQUEST r
-)
-{
-    UNREFERENCED_PARAMETER(ctrl);
-    UNREFERENCED_PARAMETER(ep);
-    UNREFERENCED_PARAMETER(r);
-
-    // TODO: endpoint reset. will require a different function prototype
-}
-
-
 
 NTSTATUS
 UsbCreateEndpointObj(

--- a/UDEFX2/usbdevice.c
+++ b/UDEFX2/usbdevice.c
@@ -169,8 +169,7 @@ Usb_Initialize(
 
     callbacks.EvtUsbDeviceLinkPowerEntry = UsbDevice_EvtUsbDeviceLinkPowerEntry;
     callbacks.EvtUsbDeviceLinkPowerExit = UsbDevice_EvtUsbDeviceLinkPowerExit;
-    callbacks.EvtUsbDeviceSetFunctionSuspendAndWake = UsbDevice_EvtUsbDeviceSetFunctionSuspendAndWake;
-
+    
     UdecxUsbDeviceInitSetStateChangeCallbacks(controllerContext->ChildDeviceInit, &callbacks);
 
     //
@@ -556,24 +555,5 @@ UsbDevice_EvtUsbDeviceLinkPowerExit(
     Io_DeviceSlept(UdecxUsbDevice);
 
     LogInfo(TRACE_DEVICE, "USB Device power EXIT [wdfDev=%p, usbDev=%p], WakeSetting=%x", UdecxWdfDevice, UdecxUsbDevice, WakeSetting);
-    return STATUS_SUCCESS;
-}
-
-NTSTATUS
-UsbDevice_EvtUsbDeviceSetFunctionSuspendAndWake(
-    _In_ WDFDEVICE                        UdecxWdfDevice,
-    _In_ UDECXUSBDEVICE                   UdecxUsbDevice,
-    _In_ ULONG                            Interface,
-    _In_ UDECX_USB_DEVICE_FUNCTION_POWER  FunctionPower
-)
-{
-    UNREFERENCED_PARAMETER(UdecxWdfDevice);
-    UNREFERENCED_PARAMETER(UdecxUsbDevice);
-    UNREFERENCED_PARAMETER(Interface);
-    UNREFERENCED_PARAMETER(FunctionPower);
-
-    // this never gets printed!
-    LogInfo(TRACE_DEVICE, "USB Device SuspendAwakeState=%x", FunctionPower );
-
     return STATUS_SUCCESS;
 }

--- a/UDEFX2/usbdevice.h
+++ b/UDEFX2/usbdevice.h
@@ -105,7 +105,6 @@ UsbCreateEndpointObj(
 EVT_UDECX_USB_DEVICE_ENDPOINTS_CONFIGURE              UsbDevice_EvtUsbDeviceEndpointsConfigure;
 EVT_UDECX_USB_DEVICE_D0_ENTRY                         UsbDevice_EvtUsbDeviceLinkPowerEntry;
 EVT_UDECX_USB_DEVICE_D0_EXIT                          UsbDevice_EvtUsbDeviceLinkPowerExit;
-EVT_UDECX_USB_DEVICE_SET_FUNCTION_SUSPEND_AND_WAKE    UsbDevice_EvtUsbDeviceSetFunctionSuspendAndWake;
 EVT_UDECX_USB_ENDPOINT_RESET                          UsbEndpointReset;
 
 


### PR DESCRIPTION
Delete do-nothing callbacks related to HW prepare/release, interrupt enable/disable and USB suspend/awake. Done to get rid of unnecessary complexity.