### PR TITLE
UDEFX2: Delete unused REQUEST_CONTEXT struct

### DIFF
--- a/UDEFX2/Device.c
+++ b/UDEFX2/Device.c
@@ -70,7 +70,7 @@ Return Value:
 	WdfDeviceInitSetPnpPowerEventCallbacks(WdfDeviceInit, &wdfPnpPowerCallbacks);
 
 	WDF_OBJECT_ATTRIBUTES wdfRequestAttributes;
-	WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&wdfRequestAttributes, REQUEST_CONTEXT);
+	WDF_OBJECT_ATTRIBUTES_INIT(&wdfRequestAttributes);
 	WdfDeviceInitSetRequestAttributes(WdfDeviceInit, &wdfRequestAttributes);
 
 	//

--- a/UDEFX2/Device.h
+++ b/UDEFX2/Device.h
@@ -52,22 +52,6 @@ typedef struct _UDECX_USBCONTROLLER_CONTEXT {
 WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(UDECX_USBCONTROLLER_CONTEXT, GetUsbControllerContext);
 
 
-typedef struct _REQUEST_CONTEXT {
-	UINT32 unused;
-} REQUEST_CONTEXT, *PREQUEST_CONTEXT;
-
-WDF_DECLARE_CONTEXT_TYPE(REQUEST_CONTEXT);
-
-
-
-
-
-
-
-
-
-
-
 //
 // Function to initialize the device and its callbacks
 //


### PR DESCRIPTION
Done to simplify the driver